### PR TITLE
Add 'requireProvider' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ template-module: {
 
 which would produce `/*jshint unused:false, asi:true, expr:true*/` and add it to the bottom of the file.
 
+#### requireProvider
+Type: ```boolean```
+Default: true
+
+When compiling as with `module: true`, by default we'll prepend `var _ = require('underscore');` to the output. This is fine if you're bundling your `provider` (underscore, lodash, or ejs) in your build.
+
+However, you might not want to bundle your `provider`, for example if you want to load lodash from a CDN. In that case, you'll want to set `requireProvider: false`
+
 #### amdWrapper
 Type: ```boolean``` | ```string```
 Default: false

--- a/tasks/template-module.js
+++ b/tasks/template-module.js
@@ -64,6 +64,7 @@ module.exports = function ( grunt ) {
 				//				unused : false, asi : true, expr : true
 			},
 			module           : true,
+			requireProvider  : true,
 			provider         : "underscore",
 			processName      : function ( name ) {
 				return name;
@@ -93,6 +94,7 @@ module.exports = function ( grunt ) {
 			};
 		} else {
 			options.module = false;
+			options.requireProvider = false;
 			options.namespace = options.namespace || "JST";
 			nsInfo = getNamespaceDeclaration( options.namespace );
 		}
@@ -132,7 +134,7 @@ module.exports = function ( grunt ) {
 					var amdDefine = typeof options.amdWrapper === "string" ? options.amdWrapper : "define(function(){";
 					output.unshift( amdDefine );
 					output.push( "  return " + nsInfo.namespace + ";\n});" );
-				} else if ( options.module ) {
+				} else if ( options.requireProvider ) {
 					output.unshift( ["var _ = require('" + options.provider + "');"] );
 				}
 				if ( options.lintExpr && !sys.isEmpty( options.lintExpr ) ) {


### PR DESCRIPTION
When compiling as with `module: true`, it prepends `var _ = require('underscore');` to the output. This means you have to bundle the provider in the same build. But it won't work if you want to load underscore/lodash/ejs from a CDN. This pull request adds a `requireProvider` option, defaulting to `true`.
