### PR TITLE
Add support for filename and template includes for ejs

### DIFF
--- a/tasks/template-module.js
+++ b/tasks/template-module.js
@@ -116,6 +116,7 @@ module.exports = function ( grunt ) {
 				var src = grunt.file.read( fpath );
 				try {
 					if ( options.provider === "ejs" ) {
+						options.templateSettings.filename = fpath;
 						compiled = templateProvider.compile( src, options.templateSettings );
 					} else {
 						compiled = templateProvider.template( src, false, options.templateSettings ).source;


### PR DESCRIPTION
Passing the filename param to ejs so that the templating engine will pick up includes when compiling.